### PR TITLE
Remove stated support for Ruby 1.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Representable is helpful for all kind of mappings, rendering and parsing workflo
 
 ## Installation
 
-The representable gem runs with all Ruby versions >= 1.8.7.
+The representable gem runs with all supported Ruby versions.
 
 ```ruby
 gem 'representable'


### PR DESCRIPTION
* Claim is not actually true: various Ruby 1.9/2.x syntax usages in codebase
* No longer supported