### PR TITLE
Fix supported Ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Representable is helpful for all kind of mappings, rendering and parsing workflo
 
 ## Installation
 
-The representable gem runs with all Ruby versions >= 1.8.7.
+The representable gem runs with all Ruby versions >= 1.9.3.
 
 ```ruby
 gem 'representable'


### PR DESCRIPTION
* Claim is not actually true: various Ruby 1.9/2.x syntax usages in codebase
* 1.8.7 is no longer supported