### PR TITLE
Adds render_nil macro to render all nil values

### DIFF
--- a/lib/representable/declarative.rb
+++ b/lib/representable/declarative.rb
@@ -4,6 +4,10 @@ module Representable
       @representable_attrs ||= build_config
     end
 
+    def render_nil
+      @render_nil = true
+    end
+
     def representation_wrap=(name)
       representable_attrs.wrap = name
     end
@@ -32,7 +36,11 @@ module Representable
       property(name, options, &block)
     end
 
-    def property(name, options={}, &block)
+    def property(name, options = {}, &block)
+      if @render_nil
+        options[:render_nil] = true
+      end
+
       representable_attrs.add(name, options) do |default_options| # handles :inherit.
         build_definition(name, default_options, &block)
       end

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -326,6 +326,22 @@ class RepresentableTest < MiniTest::Spec
       end
     end
 
+    describe "when the render_nil macro is used" do
+      it "includes nil attribute" do
+        mod = Module.new do
+          include Representable::JSON
+          render_nil
+          property :name
+          property :groupies
+        end
+
+        @band.extend(mod) # FIXME: use clean object.
+        @band.groupies = nil
+        hash = @band.to_hash
+        assert_equal({"name"=>"No One's Choice", "groupies" => nil}, hash)
+      end
+    end
+
     it "does not propagate private options to nested objects" do
       cover_rpr = Module.new do
         include Representable::Hash


### PR DESCRIPTION
This makes it easier to render all nil properties instead of having to explicitly say so for each property:

``` ruby
Module.new do
  include Representable::JSON
  render_nil
  property :name
  property :groupies
end
```

The problem with a `default_options` method as discussed e.g. [here](https://github.com/apotonick/representable/issues/43) is that there are various methods that all take different options, thus it would be unclear which default options would be applied to which method etc.
