### PR TITLE
Add "defaults" DSL that helps to declare properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1314,6 +1314,34 @@ end
 
 This is an implementation detail most people shouldn't worry about.
 
+
+### Defaults
+
+Declaring default options for `property`, `nested`, `collection` and `hash` is
+easy as:
+
+```ruby
+defaults render_nil: true
+```
+
+You can also pass a block for dynamic default options based on the property
+name or on the property options.
+
+```ruby
+defaults render_nil: true do |name|
+  { as: name.to_s.camelize }
+end
+```
+
+```ruby
+defaults render_nil: true do |name, options|
+  {
+    as: name.to_s.camelize,
+    embedded: options.fetch(:hash, false)
+  }
+end
+```
+
 ## Symbol Keys vs. String Keys
 
 When parsing representable reads properties from hashes by using their string keys.

--- a/test/defaults_options_test.rb
+++ b/test/defaults_options_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+
+class DefaultsOptionsTest < BaseTest
+  let (:format) { :hash }
+  let (:song) { Struct.new(:title, :author_name, :song_volume, :description).new("Revolution", "Some author", 20, nil) }
+  let (:prepared) { representer.prepare song }
+
+  describe "hash options combined with dynamic options" do
+    representer! do
+      defaults render_nil: true do |name|
+        { as: name.to_s.camelize }
+      end
+
+      property :title
+      property :author_name
+      property :description
+      property :song_volume
+    end
+
+    it { render(prepared).must_equal_document({"Title" => "Revolution", "AuthorName" => "Some author", "Description" => nil, "SongVolume" => 20}) }
+  end
+
+  describe "with only dynamic property options" do
+    representer! do
+      defaults do |name|
+        { as: name.to_s.camelize }
+      end
+
+      property :title
+      property :author_name
+      property :description
+      property :song_volume
+    end
+
+    it { render(prepared).must_equal_document({"Title" => "Revolution", "AuthorName" => "Some author", "SongVolume" => 20}) }
+  end
+
+  describe "with only hashes" do
+    representer! do
+      defaults render_nil: true
+
+      property :title
+      property :author_name
+      property :description
+      property :song_volume
+    end
+
+    it { render(prepared).must_equal_document({"title" => "Revolution", "author_name" => "Some author", "description" => nil, "song_volume" => 20}) }
+  end
+
+  describe "direct defaults hash" do
+    representer! do
+      defaults render_nil: true
+
+      property :title
+      property :author_name
+      property :description
+      property :song_volume
+    end
+
+    it { render(prepared).must_equal_document({"title" => "Revolution", "author_name" => "Some author", "description" => nil, "song_volume" => 20}) }
+  end
+
+  describe "direct defaults hash with dynamic options" do
+    representer! do
+      defaults render_nil: true do |name|
+        { as: name.to_s.camelize }
+      end
+
+      property :title
+      property :author_name
+      property :description
+      property :song_volume
+    end
+
+    it { render(prepared).must_equal_document({"Title" => "Revolution", "AuthorName" => "Some author", "Description" => nil, "SongVolume" => 20}) }
+  end
+
+  describe "prioritizes specific options" do
+    representer! do
+      defaults render_nil: true do |name|
+        { as: name.to_s.camelize }
+      end
+
+      property :title
+      property :author_name
+      property :description, render_nil: false
+      property :song_volume, as: :volume
+    end
+
+    it { render(prepared).must_equal_document({"Title" => "Revolution", "AuthorName" => "Some author", "volume" => 20}) }
+  end
+end


### PR DESCRIPTION
Hey @apotonick , this is a proposal for these issues: 

https://github.com/apotonick/representable/pull/136
https://github.com/apotonick/representable/pull/131
https://github.com/apotonick/representable/issues/43

The code is implemented. I'll add some documentation..

I'll write something to the `links` methods too.

```ruby
  class SongRepresenter < ...
    defaults do
      property render_nil: true
    end
  end
```
or

```ruby
  class SongRepresenter < ...
    defaults do
      property render_nil: true do |name|
       { as: name.to_s.camelize }
      end
    end
  end
```
or even with hashes ...

```ruby
  class SongRepresenter < ...
    defaults property: { render_nil: true }
  end
````