### PR TITLE
don't send skipable_empty_value?

### DIFF
--- a/lib/representable/serializer.rb
+++ b/lib/representable/serializer.rb
@@ -18,7 +18,7 @@ module Representable
   end
 
   StopOnSkipable = ->(input, options) do
-    options[:binding].send(:skipable_empty_value?, input) ? Pipeline::Stop : input
+    options[:binding].skipable_empty_value?(input) ? Pipeline::Stop : input
   end
 
   RenderFilter = ->(input, options) do


### PR DESCRIPTION
`skipable_empty_value?` is a public method on `binding`, so we don't need to send it