### PR TITLE
Use Setter in OverwriteOnNil if a :setter is defined

### DIFF
--- a/lib/representable/deserializer.rb
+++ b/lib/representable/deserializer.rb
@@ -20,7 +20,13 @@ module Representable
   end
 
   OverwriteOnNil = ->(input, options) do
-    input.nil? ? (SetValue.(input, options); Pipeline::Stop) : input
+    if input.nil?
+      function = options[:binding][:setter] ? Setter : SetValue
+      function.(input, options)
+      Pipeline::Stop
+    else
+      input
+    end
   end
 
   Default = ->(input, options) do

--- a/test/getter_setter_test.rb
+++ b/test/getter_setter_test.rb
@@ -18,4 +18,9 @@ class GetterSetterTest < BaseTest
     subject.instance_eval { def name=(*); raise; end; self }
     subject.from_hash({"name" => "Eyes Without A Face"}, user_options: {welcome: "Hello"}).song_name.must_equal "Hello Eyes Without A Face"
   end
+
+  it "uses :setter when parsing if set value is nil" do
+    subject.instance_eval { def name=(*); raise('used SetValue instead of Setter'); end; self }
+    subject.from_hash({"name" => nil}, user_options: {welcome: "Hello"}).song_name.must_equal "Hello "
+  end
 end


### PR DESCRIPTION
I might be misunderstanding the intention of `OverwriteOnNil`, but it seems like you'd want to use `Setter` if a `:setter` is defined for the property.

If I am misunderstanding, please clarify why the supplied test case is invalid. Thanks!