### PR TITLE
wrap result of ::Hash::Binding::Collection#read if it is a Hash

### DIFF
--- a/lib/representable/hash/binding.rb
+++ b/lib/representable/hash/binding.rb
@@ -26,6 +26,12 @@ module Representable
 
       class Collection < self
         include Representable::Binding::Collection
+
+        def read(hash, as)
+          collection = super
+          collection = [collection] if collection.is_a?(::Hash)
+          collection
+        end
       end
     end
   end


### PR DESCRIPTION
The JSON-HAL specification allows a single Resource Object in the _embedded property.

> 4.1.2.  _embedded
> 
>    The reserved "_embedded" property is OPTIONAL
> 
>    It is an object whose property names are link relation types (as
>    defined by [RFC5988]) and values are either **a Resource Object or an**
>    **array of Resource Objects**.

Currently an Exceptions is thrown if the representer expects a collection instead of a property. This commit will fix it.