### PR TITLE
OpenStruct decoration support fixed.

### DIFF
--- a/lib/representable/serializer.rb
+++ b/lib/representable/serializer.rb
@@ -3,7 +3,7 @@ module Representable
     options[:binding].evaluate_option(:getter, input, options)
   end
 
-  GetValue = ->(input, options) { options[:binding].send(:exec_context, options).send(options[:binding].getter) }
+  GetValue = ->(input, options) { options[:binding].send(:exec_context, options).public_send(options[:binding].getter) }
 
   Writer = ->(input, options) do
     options[:binding].evaluate_option(:writer, input, options)

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -12,8 +12,17 @@ class DecoratorTest < MiniTest::Spec
     collection :songs, :class => Song, :extend => SongRepresentation
   end
 
+  class RatingRepresentation < Representable::Decorator
+    include Representable::JSON
+
+    property :system
+    property :value
+  end
+
   let (:song) { Song.new("Mama, I'm Coming Home") }
   let (:album) { Album.new([song]) }
+
+  let (:rating) { OpenStruct.new(system: 'MPAA', value: 'R') }
 
   describe "inheritance" do
     let (:inherited_decorator) do
@@ -27,12 +36,16 @@ class DecoratorTest < MiniTest::Spec
 
   let (:decorator) { AlbumRepresentation.new(album) }
 
+  let(:rating_decorator) { RatingRepresentation.new(rating) }
+
   it "renders" do
     decorator.to_hash.must_equal({"songs"=>[{"name"=>"Mama, I'm Coming Home"}]})
     album.wont_respond_to :to_hash
     song.wont_respond_to :to_hash # DISCUSS: weak test, how to assert blank slate?
     # no @representable_attrs in decorated objects
     song.instance_variable_get(:@representable_attrs).must_equal nil
+
+    rating_decorator.to_hash.must_equal({"system" => "MPAA", "value" => "R"})
   end
 
   describe "#from_hash" do


### PR DESCRIPTION
Decorating `OpenStruct` which has accessors like `system` fails due to you using `send` instead of `public_send`, because of a fallback to `Kernel#system`.

``` ruby
require 'ostruct'

rating = OpenStruct.new(system: 'MPAA', value: 'R')

require 'representable'
require 'representable/json'

class RatingRepresenter < Representable::Decorator
  include Representable::JSON

  property :system
  property :value
end

RatingRepresenter.new(rating).to_hash
# => ArgumentError: wrong number of arguments (given 0, expected 1+)
```

Thought this should be fixed, cause you use `OpenStruct` in your other gems a lot.
