### PR TITLE
Pass options to getters and setters

### DIFF
--- a/lib/representable/deserializer.rb
+++ b/lib/representable/deserializer.rb
@@ -88,8 +88,18 @@ module Representable
   end
 
   Setter   = ->(input, options) { options[:binding].evaluate_option(:setter, input, options) }
-  SetValue = ->(input, options) { options[:binding].send(:exec_context, options).send(options[:binding].setter, input) }
 
+  SetValue = ->(input, options) do
+    context = options[:binding].send(:exec_context, options)
+
+    arguments = [input]
+    arguments << {
+      options: options[:options],
+      user_options: options[:options][:user_options]
+    } if context.method(options[:binding].setter).arity == 2
+
+    context.send(options[:binding].setter, *arguments)
+  end
 
   Stop = ->(*) { Pipeline::Stop }
 

--- a/lib/representable/deserializer.rb
+++ b/lib/representable/deserializer.rb
@@ -96,7 +96,7 @@ module Representable
     arguments << {
       options: options[:options],
       user_options: options[:options][:user_options]
-    } if context.method(options[:binding].setter).arity == 2
+    } if !context.is_a?(OpenStruct) && context.method(options[:binding].setter).arity == 2
 
     context.send(options[:binding].setter, *arguments)
   end

--- a/lib/representable/serializer.rb
+++ b/lib/representable/serializer.rb
@@ -4,16 +4,15 @@ module Representable
   end
 
   GetValue = ->(input, options) do
-    exec_context = options[:binding].send(:exec_context, options)
-    getter_method = exec_context.method(options[:binding].getter)
+    context = options[:binding].send(:exec_context, options)
 
-    if getter_method.arity > 0
-      arguments = [{ options: options[:options] }]
-    else
-      arguments = []
-    end
+    arguments = []
+    arguments << {
+      options: options[:options],
+      user_options: options[:options][:user_options]
+    } if context.method(options[:binding].getter).arity == 1
 
-    exec_context.send(options[:binding].getter, *arguments)
+    context.send(options[:binding].getter, *arguments)
   end
 
   Writer = ->(input, options) do

--- a/lib/representable/serializer.rb
+++ b/lib/representable/serializer.rb
@@ -10,7 +10,7 @@ module Representable
     arguments << {
       options: options[:options],
       user_options: options[:options][:user_options]
-    } if context.method(options[:binding].getter).arity == 1
+    } if !context.is_a?(OpenStruct) && context.method(options[:binding].getter).arity == 1
 
     context.send(options[:binding].getter, *arguments)
   end

--- a/lib/representable/serializer.rb
+++ b/lib/representable/serializer.rb
@@ -3,7 +3,18 @@ module Representable
     options[:binding].evaluate_option(:getter, input, options)
   end
 
-  GetValue = ->(input, options) { options[:binding].send(:exec_context, options).send(options[:binding].getter) }
+  GetValue = ->(input, options) do
+    exec_context = options[:binding].send(:exec_context, options)
+    getter_method = exec_context.method(options[:binding].getter)
+
+    if getter_method.arity > 0
+      arguments = [{ options: options[:options] }]
+    else
+      arguments = []
+    end
+
+    exec_context.send(options[:binding].getter, *arguments)
+  end
 
   Writer = ->(input, options) do
     options[:binding].evaluate_option(:writer, input, options)


### PR DESCRIPTION
This PR allows to do the following:

```ruby
class SongDecorator < Representable::Decorator
  property :title, exec_context: :decorator

  def title(user_options:, **)
    user_options[:upcase_title] ? represented.title.upcase : represented.title
  end
end
```

And also:

```ruby
class SongDecorator < Representable::Decorator
  property :title, exec_context: :decorator

  def title=(input, user_options:, **)
    super(user_options[:upcase_title] ? input.upcase : input)
  end
end
```

In addition to accepting the `user_options` keyword argument, the methods can also accept `options`, if the full options hash is needed.