### PR TITLE
Teach #from_hash to raise TypeError  when argument is not a Hash

### DIFF
--- a/lib/representable/hash.rb
+++ b/lib/representable/hash.rb
@@ -26,6 +26,7 @@ module Representable
 
     def from_hash(data, options={}, binding_builder=Binding)
       data = filter_wrap(data, options)
+      raise TypeError, "Expected Hash, got #{data.class}." unless ::Hash === data
 
       update_properties_from(data, options, binding_builder)
     end

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -27,6 +27,13 @@ class HashWithScalarPropertyTest < MiniTest::Spec
       album.title.must_equal nil
       album.extend(representer).from_hash("title" => nil)
     end
+
+    it 'raises a TypeError when argument is not a Hash' do
+      from_hash = -> {
+        album.extend(representer).from_hash('not Hashish')
+      }.must_raise TypeError
+      from_hash.message.must_equal 'Expected Hash, got String.'
+    end
   end
 end
 

--- a/test/wrap_test.rb
+++ b/test/wrap_test.rb
@@ -80,6 +80,11 @@ class HashDisableWrapTest < MiniTest::Spec
     band.from_hash({band: {"name"=>"Social Distortion"}}, wrap: :band).name.must_equal "Social Distortion"
   end
 
+  it 'raises a TypeError when unwrapped argument is not a Hash' do
+    -> { band.from_hash('bands' => '')         }.must_raise TypeError
+    -> { band.from_hash('', wrap: false)       }.must_raise TypeError
+    -> { band.from_hash({'band' => ''}, wrap: :band) }.must_raise TypeError
+  end
 
   class AlbumDecorator < Representable::Decorator
     include Representable::Hash
@@ -149,4 +154,3 @@ class XMLDisableWrapTest < MiniTest::Spec
   #   album.from_hash({"albums" => {"band" => {"name"=>"Rvivr"}}}).band.name.must_equal "Rvivr"
   # end
 end
-

--- a/test/wrap_test.rb
+++ b/test/wrap_test.rb
@@ -76,8 +76,8 @@ class HashDisableWrapTest < MiniTest::Spec
 
   it do
     band.from_hash({"bands" => {"name"=>"Social Distortion"}}).name.must_equal "Social Distortion"
-    band.from_hash({"name"=>"Social Distortion"}, wrap: false).name.must_equal "Social Distortion"
-    band.from_hash({band: {"name"=>"Social Distortion"}}, wrap: :band).name.must_equal "Social Distortion"
+    band.from_hash({"name"=>"Bad Religion"}, wrap: false).name.must_equal "Bad Religion"
+    band.from_hash({"band"=>{"name"=>"Pennywise"}}, wrap: :band).name.must_equal "Pennywise"
   end
 
   it 'raises a TypeError when unwrapped argument is not a Hash' do


### PR DESCRIPTION
@apotonick An alternative would be for `#from_hash` to fail silently (i.e. `data = {} unless ::Hash === data`). However, I think raising a `TypeError` makes more sense in a web application context. it allows the `Operation` or web framework Controller to rescue `TypeError` and return a `400` to the client.